### PR TITLE
Update Pywikipedia documentation and links

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -31,5 +31,5 @@ following code (via the API_)::
         return mwparserfromhell.parse(text)
 
 .. _EarwigBot:            https://github.com/earwig/earwigbot
-.. _Pywikipedia:          http://pywikipediabot.sourceforge.net/
+.. _Pywikipedia:          https://www.mediawiki.org/wiki/Manual:Pywikipediabot
 .. _API:                  http://mediawiki.org/wiki/API


### PR DESCRIPTION
I fixed the Pywikipedia example, and changed the link to point to the portal on mediawiki.org which is more up to date than the sf.net page.
