### PR TITLE
Force opening README.rst as utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ from setuptools import setup, find_packages, Extension
 from mwparserfromhell import __version__
 from mwparserfromhell.compat import py26, py3k
 
-with open("README.rst") as fp:
+with open("README.rst", **{'encoding':'utf-8'} if py3k else {}) as fp:
     long_docs = fp.read()
 
 tokenizer = Extension("mwparserfromhell.parser._tokenizer",


### PR DESCRIPTION
Causes issues if the locale is not set to utf-8.

https://stackoverflow.com/questions/23917729/switching-to-python-3-causing-unicodedecodeerror
