### PR TITLE
Use 3.5 nightly in build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - 3.2
     - 3.3
     - 3.4
-    - nightly
+    - 3.5-dev
 install:
     - pip install coveralls
     - python setup.py build


### PR DESCRIPTION
'nightly' now follows Python 3.6
Use '3.5-dev' for Python 3.5 nightly
http://docs.travis-ci.com/user/languages/python/#On-demand-installations

Partially resolves issue #112