### PR TITLE
setup.py: Make source files be in a deterministic order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ if fallback:
 # Project-specific part begins here:
 
 tokenizer = Extension("mwparserfromhell.parser._tokenizer",
-                      sources=glob("mwparserfromhell/parser/ctokenizer/*.c"),
+                      sources=sorted(glob("mwparserfromhell/parser/ctokenizer/*.c")),
                       depends=glob("mwparserfromhell/parser/ctokenizer/*.h"))
 
 setup(


### PR DESCRIPTION
To make the package build reproducibly, sort the source files in a
deterministic order instead of just globbing them.

Patch originally from
<https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=842628>.