### PR TITLE
fix example: wrap dict.values in list()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,7 @@ Python 3 code (via the API_)::
                 "rvprop": "content", "format": "json", "titles": title}
         raw = urlopen(API_URL, urlencode(data).encode()).read()
         res = json.loads(raw)
-        text = res["query"]["pages"].values()[0]["revisions"][0]["*"]
+        text = list(res["query"]["pages"].values())[0]["revisions"][0]["*"]
         return mwparserfromhell.parse(text)
 
 .. _MediaWiki:              http://mediawiki.org


### PR DESCRIPTION
In Python 3, `dict.values` returns a dict_values object, which does not support indexing.