### PR TITLE
Some fixes for the parsing of external links

### DIFF
--- a/mwparserfromhell/nodes/external_link.py
+++ b/mwparserfromhell/nodes/external_link.py
@@ -27,15 +27,18 @@ __all__ = ["ExternalLink"]
 class ExternalLink(Node):
     """Represents an external link, like ``[http://example.com/ Example]``."""
 
-    def __init__(self, url, title=None, brackets=True):
+    def __init__(self, url, title=None, brackets=True, suppress_space=False):
         super().__init__()
         self.url = url
         self.title = title
         self.brackets = brackets
+        self.suppress_space = suppress_space
 
     def __str__(self):
         if self.brackets:
             if self.title is not None:
+                if self.suppress_space is True:
+                    return "[" + str(self.url) + str(self.title) + "]"
                 return "[" + str(self.url) + " " + str(self.title) + "]"
             return "[" + str(self.url) + "]"
         return str(self.url)

--- a/mwparserfromhell/parser/builder.py
+++ b/mwparserfromhell/parser/builder.py
@@ -157,17 +157,20 @@ class Builder:
     @_add_handler(tokens.ExternalLinkOpen)
     def _handle_external_link(self, token):
         """Handle when an external link is at the head of the tokens."""
-        brackets, url = token.brackets, None
+        brackets, url, suppress_space = token.brackets, None, None
         self._push()
         while self._tokens:
             token = self._tokens.pop()
             if isinstance(token, tokens.ExternalLinkSeparator):
                 url = self._pop()
+                suppress_space = token.suppress_space
                 self._push()
             elif isinstance(token, tokens.ExternalLinkClose):
                 if url is not None:
-                    return ExternalLink(url, self._pop(), brackets)
-                return ExternalLink(self._pop(), brackets=brackets)
+                    return ExternalLink(url, self._pop(), brackets=brackets,
+                                        suppress_space=suppress_space is True)
+                return ExternalLink(self._pop(), brackets=brackets,
+                                    suppress_space=suppress_space is True)
             else:
                 self._write(self._handle_token(token))
         raise ParserError("_handle_external_link() missed a close token")

--- a/mwparserfromhell/parser/ctokenizer/tok_parse.c
+++ b/mwparserfromhell/parser/ctokenizer/tok_parse.c
@@ -30,7 +30,7 @@ SOFTWARE.
 #define DIGITS    "0123456789"
 #define HEXDIGITS "0123456789abcdefABCDEF"
 #define ALPHANUM  "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-#define URISCHEME "abcdefghijklmnopqrstuvwxyz0123456789+.-"
+#define URISCHEME "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+.-"
 
 #define MAX_BRACES 255
 #define MAX_ENTITY_SIZE 8

--- a/mwparserfromhell/parser/tokenizer.py
+++ b/mwparserfromhell/parser/tokenizer.py
@@ -393,7 +393,8 @@ class Tokenizer:
             # scheme since it was just parsed as text:
             for chunk in reversed(self._textbuffer):
                 for char in reversed(chunk):
-                    if char.isspace() or char in self.MARKERS:
+                    # stop at the first non-word character
+                    if re.fullmatch(r"\W", char):
                         raise StopIteration()
                     if char not in valid:
                         raise BadRoute()

--- a/mwparserfromhell/parser/tokenizer.py
+++ b/mwparserfromhell/parser/tokenizer.py
@@ -366,7 +366,7 @@ class Tokenizer:
             self._emit_text("//")
             self._head += 2
         else:
-            valid = "abcdefghijklmnopqrstuvwxyz0123456789+.-"
+            valid = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+.-"
             all_valid = lambda: all(char in valid for char in self._read())
             scheme = ""
             while self._read() is not self.END and all_valid():
@@ -386,7 +386,7 @@ class Tokenizer:
 
     def _parse_free_uri_scheme(self):
         """Parse the URI scheme of a free (no brackets) external link."""
-        valid = "abcdefghijklmnopqrstuvwxyz0123456789+.-"
+        valid = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+.-"
         scheme = []
         try:
             # We have to backtrack through the textbuffer looking for our

--- a/mwparserfromhell/parser/tokenizer.py
+++ b/mwparserfromhell/parser/tokenizer.py
@@ -439,7 +439,7 @@ class Tokenizer:
         # Built from _parse()'s end sentinels:
         after, ctx = self._read(2), self._context
         equal_sign_contexts = contexts.TEMPLATE_PARAM_KEY | contexts.HEADING
-        return (this in (self.END, "\n", "[", "]", "<", ">") or
+        return (this in (self.END, "\n", "[", "]", "<", ">", "\"") or
                 this == nxt == "'" or
                 (this == "|" and ctx & contexts.TEMPLATE) or
                 (this == "=" and ctx & equal_sign_contexts) or
@@ -482,16 +482,29 @@ class Tokenizer:
                 self._parse_template_or_argument()
             elif this == "]":
                 return self._pop(), tail, 0
-            elif " " in this:
-                before, after = this.split(" ", 1)
+            elif this == "'" and nxt == "'":
+                separator = tokens.ExternalLinkSeparator()
+                separator.suppress_space = True
+                self._emit(separator)
+                self._context ^= contexts.EXT_LINK_URI
+                self._context |= contexts.EXT_LINK_TITLE
+                return self._parse(push=False), None, 0
+            elif any(ch in this for ch in (" ", "\n", "[", "]", "<", ">",
+                                           "\"")):
+                before, after = re.split("[ \n\[\]<>\"]", this, maxsplit=1)
+                delimiter = this[len(before)]
                 if brackets:
                     self._emit_text(before)
-                    self._emit(tokens.ExternalLinkSeparator())
+                    separator = tokens.ExternalLinkSeparator()
+                    if delimiter != " ":
+                        separator.suppress_space = True
+                    self._emit(separator)
                     if after:
                         self._emit_text(after)
                     self._context ^= contexts.EXT_LINK_URI
                     self._context |= contexts.EXT_LINK_TITLE
-                    self._head += 1
+                    if delimiter == " ":
+                        self._head += 1
                     return self._parse(push=False), None, 0
                 punct, tail = self._handle_free_link_text(punct, tail, before)
                 return self._pop(), tail + " " + after, 0

--- a/tests/tokenizer/external_links.mwtest
+++ b/tests/tokenizer/external_links.mwtest
@@ -478,3 +478,17 @@ name:   brackets_scheme_title_but_no_url
 label:  brackets around a scheme, colon, and slashes, with a title
 input:  "[http:// Example]"
 output: [Text(text="[http:// Example]")]
+
+---
+
+name:   url_preceded_by_non_word_character
+label:  non-word character immediately before a valid URL
+input:  "svn+ssh://server.domain.com:/reponame"
+output: [Text(text="svn+"), ExternalLinkOpen(brackets=False), Text(text="ssh://server.domain.com:/reponame"), ExternalLinkClose()]
+
+---
+
+name:   url_preceded_by_underscore
+label:  underscore immediately before a valid URL
+input:  "svn_ssh://server.domain.com:/reponame"
+output: [Text(text="svn_ssh://server.domain.com:/reponame")]

--- a/tests/tokenizer/external_links.mwtest
+++ b/tests/tokenizer/external_links.mwtest
@@ -153,9 +153,9 @@ output: [ExternalLinkOpen(brackets=True), Text(text="http://example.(com)"), Ext
 ---
 
 name:   brackets_open_bracket_inside
-label:  an open bracket inside a bracket-enclosed link that is also included
+label:  an open bracket inside a bracket-enclosed link that is not included
 input:  "[http://foobar[baz.com Example]"
-output: [ExternalLinkOpen(brackets=True), Text(text="http://foobar[baz.com"), ExternalLinkSeparator(), Text(text="Example"), ExternalLinkClose()]
+output: [ExternalLinkOpen(brackets=True), Text(text="http://foobar"), ExternalLinkSeparator(suppress_space=True), Text(text="[baz.com Example"), ExternalLinkClose()]
 
 ---
 
@@ -492,3 +492,73 @@ name:   url_preceded_by_underscore
 label:  underscore immediately before a valid URL
 input:  "svn_ssh://server.domain.com:/reponame"
 output: [Text(text="svn_ssh://server.domain.com:/reponame")]
+
+---
+
+name:   url_terminated_by_double_quote
+label:  a free link terminated by a double quote
+input:  "http://foo\"bar"
+output: [ExternalLinkOpen(brackets=False), Text(text="http://foo"), ExternalLinkClose(), Text(text="\"bar")]
+
+---
+
+name:   url_not_terminated_by_single_quote
+label:  a free link not terminated by a single quote
+input:  "http://foo'bar"
+output: [ExternalLinkOpen(brackets=False), Text(text="http://foo'bar"), ExternalLinkClose()]
+
+---
+
+name:   url_terminated_by_two_single_quotes
+label:  a free link terminated by two single quotes
+input:  "http://foo''bar''"
+output: [ExternalLinkOpen(brackets=False), Text(text="http://foo"), ExternalLinkClose(), TagOpenOpen(wiki_markup="''"), Text(text="i"), TagCloseOpen(), Text(text="bar"), TagOpenClose(), Text(text="i"), TagCloseClose()]
+
+---
+
+name:   url_terminated_by_left_angle
+label:  a free link terminated by a left angle
+input:  "http://foo<bar"
+output: [ExternalLinkOpen(brackets=False), Text(text="http://foo"), ExternalLinkClose(), Text(text="<bar")]
+
+---
+
+name:   url_terminated_by_right_angle
+label:  a free link terminated by a right angle
+input:  "http://foo>bar"
+output: [ExternalLinkOpen(brackets=False), Text(text="http://foo"), ExternalLinkClose(), Text(text=">bar")]
+
+---
+
+name:   brackets_terminated_by_double_quote
+label:  an external link terminated by a double quote
+input:  "[http://foo\"bar]"
+output: [ExternalLinkOpen(brackets=True), Text(text="http://foo"), ExternalLinkSeparator(suppress_space=True), Text(text="\"bar"), ExternalLinkClose()]
+
+---
+
+name:   brackets_not_terminated_by_single_quote
+label:  an external link not terminated by a single quote
+input:  "[http://foo'bar]"
+output: [ExternalLinkOpen(brackets=True), Text(text="http://foo'bar"), ExternalLinkClose()]
+
+---
+
+name:   brackets_terminated_by_two_single_quotes
+label:  an external link terminated by two single quotes
+input:  "[http://foo''bar'']"
+output: [ExternalLinkOpen(brackets=True), Text(text="http://foo"), ExternalLinkSeparator(suppress_space=True), TagOpenOpen(wiki_markup="''"), Text(text="i"), TagCloseOpen(), Text(text="bar"), TagOpenClose(), Text(text="i"), TagCloseClose(), ExternalLinkClose()]
+
+---
+
+name:   brackets_terminated_by_left_angle
+label:  an external link terminated by a left angle
+input:  "[http://foo<bar]"
+output: [ExternalLinkOpen(brackets=True), Text(text="http://foo"), ExternalLinkSeparator(suppress_space=True), Text(text="<bar"), ExternalLinkClose()]
+
+---
+
+name:   brackets_terminated_by_right_angle
+label:  an external link terminated by a right angle
+input:  "[http://foo>bar]"
+output: [ExternalLinkOpen(brackets=True), Text(text="http://foo"), ExternalLinkSeparator(suppress_space=True), Text(text=">bar"), ExternalLinkClose()]

--- a/tests/tokenizer/external_links.mwtest
+++ b/tests/tokenizer/external_links.mwtest
@@ -562,3 +562,17 @@ name:   brackets_terminated_by_right_angle
 label:  an external link terminated by a right angle
 input:  "[http://foo>bar]"
 output: [ExternalLinkOpen(brackets=True), Text(text="http://foo"), ExternalLinkSeparator(suppress_space=True), Text(text=">bar"), ExternalLinkClose()]
+
+---
+
+name:   scheme_case
+label:  a free link with uppercase letters in the URL scheme
+input:  "HtTp://example.com/"
+output: [ExternalLinkOpen(brackets=False), Text(text="HtTp://example.com/"), ExternalLinkClose()]
+
+---
+
+name:   bracket_scheme_case
+label:  an external link with uppercase letters in the URL scheme
+input:  "[HtTp://example.com/]"
+output: [ExternalLinkOpen(brackets=True), Text(text="HtTp://example.com/"), ExternalLinkClose()]


### PR DESCRIPTION
I think this would fix the problem reported in #197, please let me know if there are any problems with this approach.

Also, how can I port this to the C tokenizer? The condition there is
```c
if (Py_UNICODE_ISSPACE(chunk) || is_marker(chunk))
```
and I don't know how to use the `re` module or its equivalent from C Python.