### PR TITLE
Use Github Actions to build manylinux1 wheels

### DIFF
--- a/.github/workflows/build-linux-wheels.yml
+++ b/.github/workflows/build-linux-wheels.yml
@@ -1,0 +1,25 @@
+name: Build manylinux1 wheels
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build manylinux1 Python wheels
+      uses: RalfG/python-wheels-manylinux-build@916aea1f70130a34995d0236ae5c67145bfd2c4f
+      with:
+        python-versions: 'cp34-cp34m cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38'
+    - name: Move to dist/
+      run: |
+        mkdir -p dist
+        cp -v wheelhouse/*-manylinux1_x86_64.whl dist/
+    - name: Publish package to PyPi
+      # Only actually publish if a new tag was pushed
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+


### PR DESCRIPTION
Just like the Windows wheels, these allow for Linux users to install
mwparserfromhell and use the faster CTokenizer without needing to
have build tools installed.

Under the hood, this uses pypa manylinux1 docker image to build and
tag the wheels, then publishes them to pypi if a new tag was pushed.

Fixes #170.

----
You'll need to create an API token and set it as a github secret, see the links at https://github.com/pypa/gh-action-pypi-publish#usage

I tested this on test pypi: https://test.pypi.org/project/mwparserfromhell-legoktm/0.6.dev0/#files
