### PR TITLE
Use Github Actions to build macOS wheels too

### DIFF
--- a/.github/workflows/build-macos-wheels.yml
+++ b/.github/workflows/build-macos-wheels.yml
@@ -1,0 +1,33 @@
+name: Build macOS wheels
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        # macOS apparently doesn't support 3.4
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Build wheels
+      run: |
+        python -m pip install --upgrade pip wheel setuptools
+        pip wheel . -w dist/
+        ls dist/
+    - name: Publish package to PyPI
+      # Only actually publish if a new tag was pushed
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      # We can't use the pypa action because of https://github.com/pypa/gh-action-pypi-publish/issues/15
+      run: |
+        pip install twine
+        TWINE_USERNAME="__token__" \
+        TWINE_PASSWORD="${{ secrets.pypi_password }}" \
+        twine upload dist/*


### PR DESCRIPTION
For 3.5+ on the latest macOS version.

----
I haven't actually verified the built wheels work, someone with macOS can do so using the wheels I uploaded at <https://test.pypi.org/project/mwparserfromhell-legoktm/0.6.dev0/#files>.