### PR TITLE
Make nodes.template.Template a bit more dict-like

### DIFF
--- a/mwparserfromhell/nodes/template.py
+++ b/mwparserfromhell/nodes/template.py
@@ -214,6 +214,9 @@ class Template(Node):
         """Alias for :meth:`has`."""
         return self.has(name, ignore_empty)
 
+    def __contains__(self, name):
+        return self.has(name)
+
     def get(self, name, default=_UNSET):
         """Get the parameter whose name is *name*.
 

--- a/mwparserfromhell/nodes/template.py
+++ b/mwparserfromhell/nodes/template.py
@@ -29,6 +29,8 @@ from ..utils import parse_anything
 __all__ = ["Template"]
 
 FLAGS = re.DOTALL | re.UNICODE
+# Used to allow None as a valid fallback value
+_UNSET = object()
 
 class Template(Node):
     """Represents a template in wikicode, like ``{{foo}}``."""
@@ -212,19 +214,23 @@ class Template(Node):
                 self.has(name, ignore_empty)
     has_param.__doc__ = "Alias for :meth:`has`."
 
-    def get(self, name):
+    def get(self, name, default=_UNSET):
         """Get the parameter whose name is *name*.
 
         The returned object is a :class:`.Parameter` instance. Raises
-        :exc:`ValueError` if no parameter has this name. Since multiple
-        parameters can have the same name, we'll return the last match, since
-        the last parameter is the only one read by the MediaWiki parser.
+        :exc:`ValueError` if no parameter has this name. If *default* is set,
+        returns that instead. Since multiple parameters can have the same name,
+        we'll return the last match, since the last parameter is the only one
+        read by the MediaWiki parser.
         """
         name = str(name).strip()
         for param in reversed(self.params):
             if param.name.strip() == name:
                 return param
-        raise ValueError(name)
+        if default is _UNSET:
+            raise ValueError(name)
+        else:
+            return default
 
     def add(self, name, value, showkey=None, before=None,
             preserve_spacing=True):

--- a/mwparserfromhell/nodes/template.py
+++ b/mwparserfromhell/nodes/template.py
@@ -210,9 +210,9 @@ class Template(Node):
                 return True
         return False
 
-    has_param = lambda self, name, ignore_empty=False: \
-                self.has(name, ignore_empty)
-    has_param.__doc__ = "Alias for :meth:`has`."
+    def has_param(self, name, ignore_empty=False):
+        """Alias for :meth:`has`."""
+        return self.has(name, ignore_empty)
 
     def get(self, name, default=_UNSET):
         """Get the parameter whose name is *name*.

--- a/mwparserfromhell/nodes/template.py
+++ b/mwparserfromhell/nodes/template.py
@@ -214,9 +214,6 @@ class Template(Node):
         """Alias for :meth:`has`."""
         return self.has(name, ignore_empty)
 
-    def __contains__(self, name):
-        return self.has(name)
-
     def get(self, name, default=_UNSET):
         """Get the parameter whose name is *name*.
 

--- a/mwparserfromhell/nodes/template.py
+++ b/mwparserfromhell/nodes/template.py
@@ -232,6 +232,9 @@ class Template(Node):
         else:
             return default
 
+    def __getitem__(self, name):
+        return self.get(name)
+
     def add(self, name, value, showkey=None, before=None,
             preserve_spacing=True):
         """Add a parameter to the template with a given *name* and *value*.
@@ -312,6 +315,9 @@ class Template(Node):
             self.params.append(param)
         return param
 
+    def __setitem__(self, name, value):
+        return self.add(name, value)
+
     def remove(self, param, keep_field=False):
         """Remove a parameter from the template, identified by *param*.
 
@@ -357,3 +363,6 @@ class Template(Node):
             raise ValueError(name)
         for i in reversed(to_remove):
             self.params.pop(i)
+
+    def __delitem__(self, param):
+        return self.remove(param)


### PR DESCRIPTION
* Adds a default parameter to Template.get that can be returned instead of raising an exception. If the parameter is not specified, previous behavior is maintained.
* Adds `__getitem__`, `__setitem__`, and `__delitem__` methods to Template, allowing the use of `Template[param]` syntax.
* ~~Adds a `__contains__` method to Template, allowing the use of `key in Template` syntax~~
* Uses a def instead of a lambda assignment for has_param (PEP8)

Template.get should really raise a KeyError, not a ValueError, but implementing that would be a breaking change.
