### PR TITLE
add support for __str__() in wikicode object

### DIFF
--- a/mwparserfromhell/wikicode.py
+++ b/mwparserfromhell/wikicode.py
@@ -51,6 +51,9 @@ class Wikicode(StringMixIn):
     def __unicode__(self):
         return "".join([str(node) for node in self.nodes])
 
+    def __str__(self):
+        return self.__unicode__()
+
     @staticmethod
     def _get_children(node, contexts=False, restrict=None, parent=None):
         """Iterate over all child :class:`.Node`\\ s of a given *node*."""


### PR DESCRIPTION
The wikicode can be converted to unicode via `__unicode__()` but
python3 support unicode through `__str__()`. This commimt allows
python3 code to convert a wikicode into a unicode via `str([wikicode])`

## context

This surged when migrating [wikiciteparser](https://github.com/dissemin/wikiciteparser) to python3. This is a python2 library that calls `unicode([wikicode].name)` (see [here](https://github.com/dissemin/wikiciteparser/blob/e69ac50446fcdbd81fda1887be2e530545b568be/wikiciteparser/parser.py#L146)) and in python3 this fails since `unicode()` is not supported but instead `str()` should be used.

The problem is that `wikicode` did not support `__str__()` so threw an exception.