### PR TITLE
Make fallthrough explicit in tok_parse.c

### DIFF
--- a/src/mwparserfromhell/parser/ctokenizer/tok_parse.c
+++ b/src/mwparserfromhell/parser/ctokenizer/tok_parse.c
@@ -1558,6 +1558,9 @@ Tokenizer_handle_tag_close_close(Tokenizer *self)
             Py_XDECREF(so);
             Py_XDECREF(sc);
         }
+        // One of `so` or `sc` failed to allocate so we fall through to clean up the
+        // closing tag and propagate the error by returning NULL.
+        __attribute__((fallthrough));
         case -1:
             Py_DECREF(closing);
             return NULL;

--- a/src/mwparserfromhell/parser/ctokenizer/tok_parse.c
+++ b/src/mwparserfromhell/parser/ctokenizer/tok_parse.c
@@ -1557,10 +1557,11 @@ Tokenizer_handle_tag_close_close(Tokenizer *self)
             }
             Py_XDECREF(so);
             Py_XDECREF(sc);
+            // One of `so` or `sc` failed to allocate so we clean up the
+            // closing tag and propagate the error by returning NULL.
+            Py_DECREF(closing);
+            return NULL;
         }
-        // One of `so` or `sc` failed to allocate so we fall through to clean up the
-        // closing tag and propagate the error by returning NULL.
-        __attribute__((fallthrough));
         case -1:
             Py_DECREF(closing);
             return NULL;


### PR DESCRIPTION
In response to #325. Allows `-Wimplicit-fallthrough` to pass.