### PR TITLE
Fix mixed-allocator heap corruption in C tokenizer entity path

### DIFF
--- a/src/mwparserfromhell/parser/ctokenizer/common.h
+++ b/src/mwparserfromhell/parser/ctokenizer/common.h
@@ -39,6 +39,7 @@ SOFTWARE.
 #endif
 
 #define malloc  PyObject_Malloc // XXX: yuck
+#define calloc  PyObject_Calloc
 #define realloc PyObject_Realloc
 #define free    PyObject_Free
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -21,6 +21,9 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
+import textwrap
 from collections.abc import Generator
 from dataclasses import dataclass
 
@@ -145,3 +148,31 @@ def test_describe_context():
     assert "" == contexts.describe(0)
     ctx = contexts.describe(contexts.TEMPLATE_PARAM_KEY | contexts.HAS_TEXT)
     assert "TEMPLATE_PARAM_KEY|HAS_TEXT" == ctx
+
+
+@pytest.mark.skipif(CTokenizer is None, reason="CTokenizer not available")
+def test_entity_does_not_corrupt_heap():
+    """Regression test: the C tokenizer must not mix raw libc calloc with
+    PyObject_Free when handling an ampersand that is not a valid entity.
+
+    Run in a subprocess with PYTHONMALLOC=debug so any allocator mismatch on
+    the entity-parsing path is reported as a fatal error rather than silent
+    heap corruption.
+    """
+    program = textwrap.dedent(
+        """
+        import mwparserfromhell
+        from mwparserfromhell.parser._tokenizer import CTokenizer
+        assert isinstance(mwparserfromhell.parser.Parser()._tokenizer, CTokenizer)
+        for text in ("a & b", "{{T|p=a & b}}", "&amp;", "&#42;", "&#x2A;"):
+            assert str(mwparserfromhell.parse(text)) == text
+        """
+    )
+    env = {**os.environ, "PYTHONMALLOC": "debug"}
+    result = subprocess.run(
+        [sys.executable, "-c", program], env=env, capture_output=True, text=True
+    )
+    assert result.returncode == 0, (
+        "C tokenizer triggered allocator mismatch under PYTHONMALLOC=debug:\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Fixes #352.

The C tokenizer was mixing allocators in the entity parsing path. `common.h` macro-redefines `malloc`, `realloc`, and `free` to Python's object allocator functions, but `calloc` was not redefined. As a result, `Tokenizer_really_parse_entity()` allocated buffers with libc `calloc()` and later released them through the macro-expanded `free()` → `PyObject_Free()`.

That allocator mismatch is undefined behavior. With `PYTHONMALLOC=debug`, it aborts immediately with `_PyMem_DebugRawFree: bad ID`; without debug malloc, it can silently corrupt the heap.

## Root cause

`src/mwparserfromhell/parser/ctokenizer/common.h` currently redirects only:

```c
#define malloc  PyObject_Malloc // XXX: yuck
#define realloc PyObject_Realloc
#define free    PyObject_Free
```

But `Tokenizer_really_parse_entity()` uses `calloc(...)` for entity parsing buffers. Those buffers are later released with `free(...)`, which expands to `PyObject_Free(...)`. This passes a libc-allocated pointer to Python's object allocator.

## Reproduction

Before this change:

```bash
PYTHONMALLOC=debug python -c "import mwparserfromhell; mwparserfromhell.parse('{{T|p=a & b}}')"
```

Actual result:

```text
Fatal Python error: _PyMem_DebugRawFree: bad ID: Allocated using API ' ', verified using API 'o'
```

Expected result: parsing succeeds and returns a `Wikicode` object without corrupting the heap.

The issue is triggered by inputs that go through the entity parsing path, for example:

```python
"a & b"
"{{T|p=a & b}}"
"&amp;"
"&#42;"
"&#x2A;"
```

## Fix

Add `calloc` to the same allocator macro block:

```c
#define malloc  PyObject_Malloc // XXX: yuck
#define calloc  PyObject_Calloc
#define realloc PyObject_Realloc
#define free    PyObject_Free
```

This makes the existing `calloc` sites use Python's allocator consistently with the surrounding `free()` calls.

## Tests

- Added a regression test that runs the parser in a subprocess with `PYTHONMALLOC=debug`, so future allocator mismatches fail deterministically instead of becoming silent heap corruption.
- Verified the regression test fails before the fix with `SIGABRT` and `_PyMem_DebugRawFree: bad ID`.
- Verified after the fix:
  - `python -m pytest tests/` — 2006 passed, 1 skipped.
  - `PYTHONMALLOC=debug python -m pytest tests/` — 2006 passed, 1 skipped.