### PR TITLE
Fix double decref after failed PyList_SetItem in C tokenizer

### DIFF
--- a/src/mwparserfromhell/parser/ctokenizer/tok_parse.c
+++ b/src/mwparserfromhell/parser/ctokenizer/tok_parse.c
@@ -1753,7 +1753,6 @@ Tokenizer_handle_single_tag_end(Tokenizer *self)
         return NULL;
     }
     if (PyList_SetItem(self->topstack->stack, index, token)) {
-        Py_DECREF(token);
         return NULL;
     }
     return Tokenizer_pop(self);


### PR DESCRIPTION
PyList_SetItem steals the item reference even on failure, so the error path must not call Py_DECREF on the same object.

Fixes: #360